### PR TITLE
fix: added new commands and bumped server to 1.0.10-nightly-v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "bin": "./node_modules/fish-lsp/bin/fish-lsp",
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.75.0",
+    "node": ">=22.0.0"
   },
   "icon": "images/fish-lsp-logo.png",
   "galleryBanner": {
@@ -195,6 +196,14 @@
       {
         "command": "fish-lsp.update.currentWorkspace",
         "title": "Fish LSP: update current workspace"
+      },
+      {
+        "command": "fish-lsp.addBundledServerToPATH",
+        "title": "Fish LSP: add bundled server to $PATH if not already present in $PATH"
+      },
+      {
+        "command": "fish-lsp.aliasBundledServer",
+        "title": "Fish LSP: alias bundled server to `fish-lsp` command"
       }
     ],
     "menus": {
@@ -311,7 +320,7 @@
     "restoreMocks": false
   },
   "dependencies": {
-    "fish-lsp": "^1.0.10",
+    "fish-lsp": "^1.0.10-nightly-v5",
     "vscode-languageclient": "9.0.1"
   },
   "devDependencies": {

--- a/test.fish
+++ b/test.fish
@@ -1,15 +1,29 @@
-# echo
-set -ga --export fish_lsp_all_indexed_paths
 
-# @fish-lsp-disable
-function __test -d 'test function' -a var1 var2 var3
+# echo
+set -ag --export fish_lsp_all_indexed_paths
+
+function __test -d 'test function' -a var1 var2 var3 --inherit-variable v --on-variable fish_lsp_all_indexed_paths
+    echo $fish_lsp_all_indexed_paths
     echo '$argv: '$argv
     echo '$var1: '$var1
-    echo '$var2: '$var2
+    echo $v
+    # echo '$var2: '$var2
     echo '$var3: '$var3
     if true
         echo a
     end
 end
+__test
 
 fish_add_path 
+
+# @fish-lsp-disable-next-line 4004
+function foo
+    __test
+
+end
+
+set -l arq_subcommands activateLicense refreshLicense ....
+#      ^^^^^^^^^^^^^^^ getReferences()
+complete -c arqc -n "not __fish_seen_subcommand_from $arq_subcommands" -a "$arq_subcommands"
+# 2 references                                        ^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^

--- a/yarn.lock
+++ b/yarn.lock
@@ -1949,10 +1949,10 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
-fish-lsp@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/fish-lsp/-/fish-lsp-1.0.10.tgz#54959de71eb5ddb0e7dbba257fd9c7b3319a0b9c"
-  integrity sha512-XxwJ7ywwce+6djZrzTRC7ljHI/d9LaxXWroSmDfaalMy2fp9p7ahl/Ozbj+X21SlU3zDUIYod+ioOLcQia8rcQ==
+fish-lsp@^1.0.10-nightly-v5:
+  version "1.0.10-nightly-v5"
+  resolved "https://registry.yarnpkg.com/fish-lsp/-/fish-lsp-1.0.10-nightly-v5.tgz#ff4593c515d8eaa3a0366f4e7be7e6aa095ffed6"
+  integrity sha512-PlDiYfLfFVgTfbfiXUZNxcmryX7Kz9A5edNSZ1/5l+QE8hSgM98Xr5UrGdPCoEhaCC2XpfLQl0yYqpxiBpB1xA==
   dependencies:
     commander "^12.0.0"
     deepmerge "^4.3.1"


### PR DESCRIPTION
## Client Changes

- now includes `fish-lsp.addBundledServerToPath` and `fish-lsp.aliasBundedServer` commands
- client now attempts to bundle `node@22` when building published extension
- extension uses `fish-lsp@1.0.10-nightly-v5` for bundled server

## Server Fixes

- [`fish-lsp issue #91`](https://github.com/ndonfris/fish-lsp/issues/91#event-18671223769)

  [Screencast from 07-16-2025 10:31:37 PM.webm](https://github.com/user-attachments/assets/9262fa68-6e89-43cb-a0ff-ff4f61ccf169)

- [`fish-lsp issue #92`](https://github.com/ndonfris/fish-lsp/issues/92#event-18671223803)

- attempts to fix [`fish-lsp issue #95`](https://github.com/ndonfris/fish-lsp/issues/95#issuecomment-3079942666)