### PR TITLE
fix: server bundled paths.extension release v0.1.12 -> v0.1.13-pre.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fish-lsp",
   "displayName": "fish-lsp",
   "description": "fish shell language support via fish-lsp",
-  "version": "0.1.13-pre.0",
+  "version": "0.1.13-pre.1",
   "license": "MIT",
   "publisher": "ndonfris",
   "author": {
@@ -350,7 +350,7 @@
     "restoreMocks": false
   },
   "dependencies": {
-    "fish-lsp": "^1.0.11-pre.14",
+    "fish-lsp": "^1.0.11-pre.15",
     "vscode-languageclient": "^9.0.1",
     "vscode-languageserver": "^9.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fish-lsp",
   "displayName": "fish-lsp",
   "description": "fish shell language support via fish-lsp",
-  "version": "0.1.12",
+  "version": "0.1.13-pre.0",
   "license": "MIT",
   "publisher": "ndonfris",
   "author": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2684,10 +2684,10 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
-fish-lsp@^1.0.11-pre.14:
-  version "1.0.11-pre.14"
-  resolved "https://registry.yarnpkg.com/fish-lsp/-/fish-lsp-1.0.11-pre.14.tgz#92b3a13b3bd69985acdb2a0884f2d6d6c5802b48"
-  integrity sha512-/ANID+R+LBpeBlvZi35+UfqtGDuZ9gmofyEJBr8lM/gvIwJKGcCLcs9J2P6kx7b+IZst8Ih+TbOR1sRvEfKe7w==
+fish-lsp@^1.0.11-pre.15:
+  version "1.0.11-pre.15"
+  resolved "https://registry.yarnpkg.com/fish-lsp/-/fish-lsp-1.0.11-pre.15.tgz#ae471875840d55f8f52554b034221692c6b54161"
+  integrity sha512-OgjG0Fg9Yh9dNiJHxmBW10DiJbWmCekNJ7rmwoQSC1q0qrq1i4LD9I7NN4N3fYCxERNRWlO6P73vYiEap4YhTA==
   dependencies:
     chalk "^5.5.0"
     commander "^12.0.0"


### PR DESCRIPTION
- bumps the server till minimum [`v1.0.11-pre.16`](https://www.npmjs.com/package/fish-lsp/v/1.0.11-pre.16)

- available to install via [pre-release](https://github.com/ndonfris/vscode-fish-lsp/releases/tag/v0.1.13-pre.2)